### PR TITLE
fix target frameworks

### DIFF
--- a/Mediapipe.Net.Runtime.CPU/Mediapipe.Net.Runtime.CPU.csproj
+++ b/Mediapipe.Net.Runtime.CPU/Mediapipe.Net.Runtime.CPU.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project">
-    <TargetFramework>net6.0;netstandard2.1</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AssemblyTitle>Mediapipe.Net.Runtime.CPU</AssemblyTitle>
     <AssemblyName>Mediapipe.Net.Runtime.CPU</AssemblyName>

--- a/Mediapipe.Net.Runtime.GPU/Mediapipe.Net.Runtime.GPU.csproj
+++ b/Mediapipe.Net.Runtime.GPU/Mediapipe.Net.Runtime.GPU.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project">
-    <TargetFramework>net6.0;netstandard2.1</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AssemblyTitle>Mediapipe.Net.Runtime.GPU</AssemblyTitle>
     <AssemblyName>Mediapipe.Net.Runtime.GPU</AssemblyName>


### PR DESCRIPTION
uses `<TargetFrameworks>` instead of `<TargetFramework>`