### PR TITLE
`proto_namespace` patch: I forgor 💀

### DIFF
--- a/Mediapipe.Net.Framework.Protobuf/Mediapipe.Net.Framework.Protobuf.csproj
+++ b/Mediapipe.Net.Framework.Protobuf/Mediapipe.Net.Framework.Protobuf.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup Label="Nuget">
     <PackageId>Mediapipe.Net.Framework.Protobuf</PackageId>
-    <Version>1.0.0-alpha1</Version>
+    <Version>1.0.0-alpha2</Version>
     <Authors>Vignette</Authors>
     <PackageTags>Google;MediaPipe;Protobuf;</PackageTags>
     <Title>Mediapipe.Net.Framework.Protobuf</Title>

--- a/Mediapipe.Net.Runtime.CPU/Mediapipe.Net.Runtime.CPU.csproj
+++ b/Mediapipe.Net.Runtime.CPU/Mediapipe.Net.Runtime.CPU.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup Label="Nuget">
     <IsPackable>true</IsPackable>
     <PackageId>Mediapipe.Net.Runtime.CPU</PackageId>
-    <Version>1.0.0-alpha1</Version>
+    <Version>1.0.0-alpha2</Version>
     <Authors>homuler;Vignette</Authors>
     <PackageTags>Google;Mediapipe;Tracking;Media Analysis</PackageTags>
     <Title>Mediapipe.Net.Runtime.CPU</Title>

--- a/Mediapipe.Net.Runtime.GPU/Mediapipe.Net.Runtime.GPU.csproj
+++ b/Mediapipe.Net.Runtime.GPU/Mediapipe.Net.Runtime.GPU.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup Label="Nuget">
     <IsPackable>true</IsPackable>
     <PackageId>Mediapipe.Net.Runtime.GPU</PackageId>
-    <Version>1.0.0-alpha1</Version>
+    <Version>1.0.0-alpha2</Version>
     <Authors>homuler;Vignette</Authors>
     <PackageTags>Google;Mediapipe;Tracking;Media Analysis</PackageTags>
     <Title>Mediapipe.Net.Runtime.GPU</Title>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,6 +58,7 @@ http_archive(
         "-p1",
     ],
     patches = [
+        "@//third_party:proto_namespace.diff",
         "@//third_party:mediapipe_opencv.diff",
         "@//third_party:mediapipe_workaround.diff",
         "@//third_party:mediapipe_visibility.diff",

--- a/third_party/proto_namespace.diff
+++ b/third_party/proto_namespace.diff
@@ -23,7 +23,7 @@ index 97d7f20..8d79ebc 100644
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/audio/spectrogram_calculator.proto b/mediapipe/calculators/audio/spectrogram_calculator.proto
-index 8e1e180..094a2e6 100644
+index b721117..872465d 100644
 --- a/mediapipe/calculators/audio/spectrogram_calculator.proto
 +++ b/mediapipe/calculators/audio/spectrogram_calculator.proto
 @@ -15,6 +15,7 @@
@@ -83,7 +83,7 @@ index 3753ffb..758fa67 100644
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/core/constant_side_packet_calculator.proto b/mediapipe/calculators/core/constant_side_packet_calculator.proto
-index 4ad497b..5ae63a3 100644
+index bc192ff..2d69c58 100644
 --- a/mediapipe/calculators/core/constant_side_packet_calculator.proto
 +++ b/mediapipe/calculators/core/constant_side_packet_calculator.proto
 @@ -15,6 +15,7 @@
@@ -382,18 +382,6 @@ index 6a5cfb0..b5444e2 100644
  
  import "mediapipe/framework/calculator.proto";
  
-diff --git a/mediapipe/calculators/tensor/audio_to_tensor_calculator.proto b/mediapipe/calculators/tensor/audio_to_tensor_calculator.proto
-index c63991f..93756d1 100644
---- a/mediapipe/calculators/tensor/audio_to_tensor_calculator.proto
-+++ b/mediapipe/calculators/tensor/audio_to_tensor_calculator.proto
-@@ -15,6 +15,7 @@
- syntax = "proto2";
- 
- package mediapipe;
-+option csharp_namespace = "Mediapipe.Net.Framework.Protobuf";
- 
- import "mediapipe/framework/calculator.proto";
- 
 diff --git a/mediapipe/calculators/tensor/image_to_tensor_calculator.proto b/mediapipe/calculators/tensor/image_to_tensor_calculator.proto
 index 780ee80..9683a0c 100644
 --- a/mediapipe/calculators/tensor/image_to_tensor_calculator.proto
@@ -443,7 +431,7 @@ index 97c2154..59934b0 100644
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/tensor/tensors_to_classification_calculator.proto b/mediapipe/calculators/tensor/tensors_to_classification_calculator.proto
-index 32bc4b6..f4346fc 100644
+index 3934a61..641e4f7 100644
 --- a/mediapipe/calculators/tensor/tensors_to_classification_calculator.proto
 +++ b/mediapipe/calculators/tensor/tensors_to_classification_calculator.proto
 @@ -17,6 +17,7 @@
@@ -453,7 +441,7 @@ index 32bc4b6..f4346fc 100644
 +option csharp_namespace = "Mediapipe.Net.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
- import "mediapipe/util/label_map.proto";
+ 
 diff --git a/mediapipe/calculators/tensor/tensors_to_detections_calculator.proto b/mediapipe/calculators/tensor/tensors_to_detections_calculator.proto
 index c9d6b69..2f7ff05 100644
 --- a/mediapipe/calculators/tensor/tensors_to_detections_calculator.proto
@@ -875,7 +863,7 @@ index f482277..135ceb2 100644
  import "mediapipe/framework/calculator.proto";
  
 diff --git a/mediapipe/calculators/util/detection_label_id_to_text_calculator.proto b/mediapipe/calculators/util/detection_label_id_to_text_calculator.proto
-index eedc5e7..b7fefa9 100644
+index bb1cf60..02e2b07 100644
 --- a/mediapipe/calculators/util/detection_label_id_to_text_calculator.proto
 +++ b/mediapipe/calculators/util/detection_label_id_to_text_calculator.proto
 @@ -15,6 +15,7 @@
@@ -1355,10 +1343,10 @@ index 747e9c4..eb7396e 100644
  option java_package = "com.google.mediapipe.proto";
  option java_outer_classname = "CalculatorOptionsProto";
 diff --git a/mediapipe/framework/calculator_profile.proto b/mediapipe/framework/calculator_profile.proto
-index 066d433..39eea41 100644
+index 723178a..df8a72e 100644
 --- a/mediapipe/framework/calculator_profile.proto
 +++ b/mediapipe/framework/calculator_profile.proto
-@@ -15,6 +15,7 @@
+@@ -19,6 +19,7 @@
  syntax = "proto2";
  
  package mediapipe;
@@ -1415,7 +1403,7 @@ index 38414df..bf5715f 100644
  option java_package = "com.google.mediapipe.formats.annotation.proto";
  option java_outer_classname = "RasterizationProto";
 diff --git a/mediapipe/framework/formats/body_rig.proto b/mediapipe/framework/formats/body_rig.proto
-index 5420ccc..4b1829a 100644
+index 094b6cb..f299a9b 100644
 --- a/mediapipe/framework/formats/body_rig.proto
 +++ b/mediapipe/framework/formats/body_rig.proto
 @@ -15,6 +15,7 @@
@@ -1547,7 +1535,7 @@ index 6b57a4a..7e10850 100644
  option java_package = "com.google.mediapipe.formats.proto";
  option java_outer_classname = "RectProto";
 diff --git a/mediapipe/framework/formats/time_series_header.proto b/mediapipe/framework/formats/time_series_header.proto
-index 6fd56c1..bd30c93 100644
+index a16f47d..f69bd10 100644
 --- a/mediapipe/framework/formats/time_series_header.proto
 +++ b/mediapipe/framework/formats/time_series_header.proto
 @@ -20,6 +20,7 @@
@@ -1556,8 +1544,8 @@ index 6fd56c1..bd30c93 100644
  package mediapipe;
 +option csharp_namespace = "Mediapipe.Net.Framework.Protobuf";
  
- option objc_class_prefix = "MediaPipe";
- 
+ // Header for a uniformly sampled time series stream. Each Packet in
+ // the stream is a Matrix, and each column is a (vector-valued) sample of
 diff --git a/mediapipe/framework/mediapipe_options.proto b/mediapipe/framework/mediapipe_options.proto
 index 0ded959..b96384f 100644
 --- a/mediapipe/framework/mediapipe_options.proto
@@ -1595,7 +1583,7 @@ index 14f13a1..0333ec9 100644
  // Options used by a PacketGenerator.
  message PacketGeneratorOptions {
 diff --git a/mediapipe/framework/packet_test.proto b/mediapipe/framework/packet_test.proto
-index 3f10911..5badd93 100644
+index bccfd6b..3afb73d 100644
 --- a/mediapipe/framework/packet_test.proto
 +++ b/mediapipe/framework/packet_test.proto
 @@ -17,6 +17,7 @@
@@ -1604,8 +1592,8 @@ index 3f10911..5badd93 100644
  package mediapipe;
 +option csharp_namespace = "Mediapipe.Net.Framework.Protobuf";
  
- option objc_class_prefix = "MediaPipe";
- 
+ message PacketTestProto {
+   // Tests that the tags used to encode the timestamp do not interfere with
 diff --git a/mediapipe/framework/status_handler.proto b/mediapipe/framework/status_handler.proto
 index 6e7ce83..a325e30 100644
 --- a/mediapipe/framework/status_handler.proto
@@ -1679,7 +1667,7 @@ index cbbe297..250439e 100644
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/test_calculators.proto b/mediapipe/framework/test_calculators.proto
-index 77dde80..978de2b 100644
+index af75dc1..b95c351 100644
 --- a/mediapipe/framework/test_calculators.proto
 +++ b/mediapipe/framework/test_calculators.proto
 @@ -19,6 +19,7 @@
@@ -1727,7 +1715,7 @@ index 50b19eb..59de7f5 100644
  import "mediapipe/framework/mediapipe_options.proto";
  
 diff --git a/mediapipe/framework/tool/calculator_graph_template.proto b/mediapipe/framework/tool/calculator_graph_template.proto
-index 27153f3..df8d2a3 100644
+index c2fc6aa..d8afedd 100644
 --- a/mediapipe/framework/tool/calculator_graph_template.proto
 +++ b/mediapipe/framework/tool/calculator_graph_template.proto
 @@ -1,6 +1,7 @@
@@ -1737,7 +1725,7 @@ index 27153f3..df8d2a3 100644
 +option csharp_namespace = "Mediapipe.Net.Framework.Protobuf";
  
  import "mediapipe/framework/calculator.proto";
- import "mediapipe/framework/calculator_options.proto";
+ import "mediapipe/framework/deps/proto_descriptor.proto";
 diff --git a/mediapipe/framework/tool/field_data.proto b/mediapipe/framework/tool/field_data.proto
 index c8713c2..d3a6a86 100644
 --- a/mediapipe/framework/tool/field_data.proto
@@ -1954,18 +1942,6 @@ index 406cc9f..bddad31 100644
  
  message TimedModelMatrixProto {
    // 4x4 model matrix stored in ROW major order.
-diff --git a/mediapipe/modules/face_detection/face_detection.proto b/mediapipe/modules/face_detection/face_detection.proto
-index f5df8d6..de82a01 100644
---- a/mediapipe/modules/face_detection/face_detection.proto
-+++ b/mediapipe/modules/face_detection/face_detection.proto
-@@ -15,6 +15,7 @@
- syntax = "proto2";
- 
- package mediapipe;
-+option csharp_namespace = "Mediapipe.Net.Framework.Protobuf";
- 
- import "mediapipe/calculators/tensor/inference_calculator.proto";
- import "mediapipe/framework/calculator_options.proto";
 diff --git a/mediapipe/modules/face_geometry/effect_renderer_calculator.proto b/mediapipe/modules/face_geometry/effect_renderer_calculator.proto
 index 6c23903..e9cda2d 100644
 --- a/mediapipe/modules/face_geometry/effect_renderer_calculator.proto
@@ -2171,7 +2147,7 @@ index c612112..609c6ed 100644
  message Color {
    optional int32 r = 1;
 diff --git a/mediapipe/util/label_map.proto b/mediapipe/util/label_map.proto
-index 79301d2..c2fd686 100644
+index 5d1123f..36c8670 100644
 --- a/mediapipe/util/label_map.proto
 +++ b/mediapipe/util/label_map.proto
 @@ -15,6 +15,7 @@


### PR DESCRIPTION
In the last huge update I completely forgot to make sure that the `proto_namespace.diff` patch was applied correctly: it wasn't, as it was removed form the `WORKSPACE` during the update after a bad manipulation and I hadn't properly checked that it worked.

Now though I did, so `Mediapipe.Net.Framework.Protobuf` is guaranteed to have the right namespace.